### PR TITLE
Fix event bubbling

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -121,7 +121,7 @@ export default Ember.EventDispatcher.extend({
 
       do {
         if (viewRegistry[target.id]) {
-          if (!viewHandler(target, event)) {
+          if (viewHandler(target, event) === false) {
             break;
           }
         } else if (target.hasAttribute('data-ember-action')) {

--- a/addon/index.js
+++ b/addon/index.js
@@ -121,8 +121,9 @@ export default Ember.EventDispatcher.extend({
 
       do {
         if (viewRegistry[target.id]) {
-          viewHandler(target, event);
-          break;
+          if (!viewHandler(target, event)) {
+            break;
+          }
         } else if (target.hasAttribute('data-ember-action')) {
           actionHandler(target, event);
           break;

--- a/tests/integration/components/test-event-dispatching-test.js
+++ b/tests/integration/components/test-event-dispatching-test.js
@@ -81,7 +81,9 @@ test('events bubble up', function(assert) {
   }));
 
   this.register('component:input-element', Component.extend({
-    tagName: 'input'
+    tagName: 'input',
+
+    focusOut() {}
   }));
 
   this.render(hbs`{{#handles-focusout}}{{input-element}}{{/handles-focusout}}`);

--- a/tests/integration/components/test-event-dispatching-test.js
+++ b/tests/integration/components/test-event-dispatching-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { click } from 'ember-native-dom-helpers';
+import { click, focus, blur } from 'ember-native-dom-helpers';
 
 const {
   Component
@@ -69,4 +69,23 @@ test('unhandled events do not trigger an error', function(assert) {
   this.render(hbs`<button>Click Me!</button>`);
 
   click('button');
+});
+
+test('events bubble up', function(assert) {
+  assert.expect(1);
+
+  this.register('component:handles-focusout', Component.extend({
+    focusOut() {
+      assert.ok(true, 'focusOut was fired!');
+    }
+  }));
+
+  this.register('component:input-element', Component.extend({
+    tagName: 'input'
+  }));
+
+  this.render(hbs`{{#handles-focusout}}{{input-element}}{{/handles-focusout}}`);
+
+  focus('input');
+  blur('input');
 });


### PR DESCRIPTION
This did not work as a drop-in replacement for me, as tests that relied on the `focusout` event bubbling up were failing, and indeed this seems to not work correctly. 
For this loop (https://github.com/rwjblue/ember-native-dom-event-dispatcher/blob/6bb3812fdba9203c927b6b5b40917d0639a8cbea/addon/index.js#L122-L132) there is always just a single iteration, as any code execution path will always hit a `break` statement on the first iteration, and never `target = target.parentNode;`.

I added a (initially failing) test, which detects the wrong behavior.

And I added a fix that *might* be ok (seems `this._bubbleEvent` returns true if the event should bubble up), at least it makes the failing test green, but better check twice! 😉