### PR TITLE
Call preventDefault() when returning false from view handler

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -121,6 +121,8 @@ export default Ember.EventDispatcher.extend({
       do {
         if (viewRegistry[target.id]) {
           if (viewHandler(target, event) === false) {
+            event.preventDefault();
+            event.stopPropagation();
             break;
           }
         } else if (target.hasAttribute('data-ember-action')) {

--- a/tests/integration/components/test-event-dispatching-test.js
+++ b/tests/integration/components/test-event-dispatching-test.js
@@ -91,3 +91,48 @@ test('events bubble up', function(assert) {
   focus('input');
   blur('input');
 });
+
+test('events are not stopped by default', function(assert) {
+  assert.expect(2);
+
+  this.on('submit', (e) => {
+    e.preventDefault();
+    assert.ok(true, 'submit was fired!');
+  });
+
+  this.register('component:submit-button', Component.extend({
+    tagName: 'button',
+    attributeBindings: ['type'],
+    type: 'submit',
+    click() {
+      assert.ok(true, 'button was clicked!');
+    }
+  }));
+
+  this.render(hbs`<form onsubmit={{action "submit"}}>{{submit-button}}</form>`);
+
+  click('button');
+});
+
+test('events are stopped when returning false from view handler', function(assert) {
+  assert.expect(1);
+
+  this.on('submit', (e) => {
+    e.preventDefault();
+    assert.notOk(true, 'submit should not be fired!');
+  });
+
+  this.register('component:submit-button', Component.extend({
+    tagName: 'button',
+    attributeBindings: ['type'],
+    type: 'submit',
+    click() {
+      assert.ok(true, 'button was clicked!');
+      return false;
+    }
+  }));
+
+  this.render(hbs`<form onsubmit={{action "submit"}}>{{submit-button}}</form>`);
+
+  click('button');
+});


### PR DESCRIPTION
Fixes #12 

@rwjblue In your comment https://github.com/rwjblue/ember-native-dom-event-dispatcher/issues/12#issuecomment-307779823 you referred to code lines that afaict handle the ("element space") action helper, but my example in that issue was about a view handler (component's `click() {}`) returning false. This is what I tried to fix in this PR.

Not sure if the action handlers also need something fixed. Referring to [the guides]() and [source](https://github.com/emberjs/ember.js/blob/91d8f08ddc030dd02bca4a331860fc2805f0bb21/packages/ember-glimmer/lib/modifiers/action.js#L106-L108) the action handler seem to handle the `preventDefault` call by themselves, right?

