### PR TITLE
add failing test case for component unit test

### DIFF
--- a/tests/dummy/app/components/my-component.js
+++ b/tests/dummy/app/components/my-component.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({});

--- a/tests/dummy/app/templates/components/my-component.hbs
+++ b/tests/dummy/app/templates/components/my-component.hbs
@@ -1,0 +1,1 @@
+This is my component

--- a/tests/unit/components/my-component-test.js
+++ b/tests/unit/components/my-component-test.js
@@ -1,0 +1,11 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('my-component', 'Unit | Component | my component', {
+  unit: true,
+});
+
+test('it works', function(assert) {
+  let component = this.subject();
+
+  assert.ok(component);
+});


### PR DESCRIPTION
This adds a failing test case for component unit tests where the event dispatcher doesn't seem to be properly replaced, see #5.