### PR TITLE
Make it a noop in Ember > 3.0.0-beta.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 let VersionChecker = require('ember-cli-version-checker');
+let hasBeenWarned = false;
 
 module.exports = {
   name: 'ember-native-dom-event-dispatcher',
@@ -8,7 +9,14 @@ module.exports = {
     this._super && this._super.init.apply(this, arguments);
 
     let checker = new VersionChecker(this);
-    this._shouldDisable = checker.forEmber().gt('3.0.0-beta.2');
+
+    this._shouldDisable = true;
+    if (checker.forEmber().lt('3.0.0-beta.2')) {
+      this._shouldDisable = false;
+    } else if (this.parent === this.project && !process.env.EMBER_TRY_CURRENT_SCENARIO && !hasBeenWarned) {
+      this.ui.writeWarnLine('ember-native-dom-event-dispatcher is not required for Ember 3.0.0-beta.2 and later, please remove from your `package.json`.');
+      hasBeenWarned = true;
+    }
   },
 
   treeFor() {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,21 @@
 'use strict';
 
+let VersionChecker = require('ember-cli-version-checker');
+
 module.exports = {
-  name: 'ember-native-dom-event-dispatcher'
+  name: 'ember-native-dom-event-dispatcher',
+  init() {
+    this._super && this._super.init.apply(this, arguments);
+
+    let checker = new VersionChecker(this);
+    this._shouldDisable = checker.forEmber().gt('3.0.0-beta.2');
+  },
+
+  treeFor() {
+    if (this._shouldDisable) {
+      return null;
+    }
+
+    return this._super.treeFor.apply(this, arguments);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.11.0"
+    "ember-cli-babel": "^6.11.0",
+    "ember-cli-version-checker": "^2.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Closes #18

Would you also output a console warning asking users to just remove the addon?
Also, should it be `gt('3.0.0-beta.2');` or `gte('3.0.0-beta.2');`?